### PR TITLE
Enable fallback to pyls for goto definition of normal python functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ Add the following configuration
 Set the project root to be ```/path/to/tvm``` using `M-x` `lsp-workspace-folders-add` `[RET]` `/path/to/tvm`
 Try out the goto definition by opening a python file
 - Move cursor to python/tvm/api.py line 59 `_api_internal._min_value`, type `M-x` `lsp-find-definition`
+
+If you use eglot instead, add the following to your init.el file.
+```el
+(add-to-list 'eglot-server-programs
+	     `(python-mode . ("python3" "-m" "tvm_ffi_navigator.langserver")))
+```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It contains a [language server](https://microsoft.github.io/language-server-prot
 
 Install dependencies
 ```bash
-pip install --user attrs python-jsonrpc-server``
+pip install --user attrs python-jsonrpc-server python-language-server``
 ```
 Then we need to ake sure tvm_ffi_navigator is in your python path in bashrc.
 ```bash


### PR DESCRIPTION
The current setting overwrites the language server with the custom one, so goto definition to normal python functions no longer work. This PR enables fallback to pyls when tvm-ffi-navigator couldn't find the definition.

Also added instructions for eglot.