### PR TITLE
Add VSCode Remote SSH Setup to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ For developing the python package locally, we can just make sure ffi_navigator i
 ```bash
 export PYTHONPATH=${PYTHONPATH}:/path/to/ffi-navigator/python
 ```
+You can also directly install fft_navigator to system Python packages so that you don't need to setup PYTHONPATH.
+Note that if you choose to install the package, you have to re-install it everytime you update the package.
+```bash
+python setup.py install
+```
 
 ### VSCode
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -11,12 +11,22 @@ You can get the extension by searching `FFI Navigator` in the VSCode marketplace
 
 ### Build from Source
 
-- Complete the python setup mentioned in the root's README
+- Complete the python setup mentioned in the root's README. It is recommended to run the setup script; otherwise you have to make sure ffi_navigator is in PYTHONPATH when running VSCode.
 - Run ```npm install && npm run compile```  on the vscode-extension folder
 - Copy the extension folder to your vscode extension folder
   - ```cp -r /path/to/ffi-navigator/vscode-extension  ~/.vscode/extensions/ffi-navigator```
 - Reload the window
 
+## Install the Extension via Remote SSH
+
+If you use VSCode Remote SSH extension to develop a project on a remote server, you can also enable ffi_navigator.
+
+- Complete the above compile and intall steps on your local machine
+- Open VSCode and connect to a remote server
+- Go to the Extensions tab in VSCode and click "install" in "FFI Navigator" extension shown in "LOCAL - INSTALLED"
+- You can now see "FFI Navigator" also appears at the "SSH: host - INSTALLED" side
+- Complete the python setup mentioned in the root's README on the remote server
+- Reload the window 
 
 ## Debug the Extension Client in VSCode Develop Mode
 


### PR DESCRIPTION
- Add VSCode remote SSH setup to README.
- Add setup.py options to README.