### PR TITLE
[VSCode Ext] Add Package Install Checker

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -6,53 +6,54 @@ import { ExtensionContext, window } from 'vscode';
 import { execSync } from 'child_process';
 
 import {
-	LanguageClient,
-	LanguageClientOptions,
-	ServerOptions,
-	ExecutableOptions
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+    ExecutableOptions
 } from 'vscode-languageclient';
 
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
-	console.log('FFI Navigator Start');
-	try {
-		execSync("pip3 show ffi_navigator");
-	} catch (error) {
-		window.showErrorMessage('ffi_navigator is not installed.' +
-								' Please run "pip3 install ffi_nagivator" and reload the window');
-		return ;
-	}
-	let pyCommand = 'python3'
- 	let args = ['-m', 'ffi_navigator.langserver']
-	let commandOptions: ExecutableOptions = { stdio: 'pipe', detached: false };
-	let serverOptions: ServerOptions = {
-		run: { command: pyCommand, args: args, options: commandOptions },
-		debug: { command: pyCommand, args: args, options: commandOptions },
-	};
+    // Check if the Python package is installed.
+    try {
+        execSync("pip3 show ffi_navigator");
+    } catch (error) {
+        window.showErrorMessage('ffi_navigator is not installed.' +
+                                ' Please run "pip3 install ffi_nagivator" and reload the window');
+        return ;
+    }
 
-	let clientOptions: LanguageClientOptions = {
-		documentSelector: [
-			{ scheme: 'file', language: 'python' },
-			{ scheme: 'file', language: 'cpp' },
-			{ scheme: 'file', language: 'c' },
-			{ scheme: 'file', language: 'plaintext' },
-		],
-		synchronize: {
-		}
-	};
-	client = new LanguageClient(
- 		'FFINavigator',
-		'FFI Navigator',
-		serverOptions,
-		clientOptions
-	);
-	client.start();
+    let pyCommand = 'python3'
+    let args = ['-m', 'ffi_navigator.langserver']
+    let commandOptions: ExecutableOptions = { stdio: 'pipe', detached: false };
+    let serverOptions: ServerOptions = {
+        run: { command: pyCommand, args: args, options: commandOptions },
+        debug: { command: pyCommand, args: args, options: commandOptions },
+    };
+
+    let clientOptions: LanguageClientOptions = {
+        documentSelector: [
+            { scheme: 'file', language: 'python' },
+            { scheme: 'file', language: 'cpp' },
+            { scheme: 'file', language: 'c' },
+            { scheme: 'file', language: 'plaintext' },
+        ],
+        synchronize: {
+        }
+    };
+    client = new LanguageClient(
+        'FFINavigator',
+        'FFI Navigator',
+        serverOptions,
+        clientOptions
+    );
+    client.start();
 }
 
 export function deactivate(): Thenable<void> | undefined {
-	if (!client) {
-		return undefined;
-	}
-	return client.stop();
+    if (!client) {
+        return undefined;
+    }
+    return client.stop();
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2,9 +2,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  * ------------------------------------------------------------------------------------------ */
-
-import * as path from 'path';
-import { workspace, ExtensionContext } from 'vscode';
+import { ExtensionContext, window } from 'vscode';
+import { execSync } from 'child_process';
 
 import {
 	LanguageClient,
@@ -16,6 +15,14 @@ import {
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
+	console.log('FFI Navigator Start');
+	try {
+		execSync("pip3 show ffi_navigator");
+	} catch (error) {
+		window.showErrorMessage('ffi_navigator is not installed.' +
+								' Please run "pip3 install ffi_nagivator" and reload the window');
+		return ;
+	}
 	let pyCommand = 'python3'
  	let args = ['-m', 'ffi_navigator.langserver']
 	let commandOptions: ExecutableOptions = { stdio: 'pipe', detached: false };


### PR DESCRIPTION
1. Add a checker when launching the extension. The client will not be launched if the checker failed so that we can avoid client errors.

2. Fix tabs by changing them to 4 spaces.