### PR TITLE
Add support for MXNet

### DIFF
--- a/python/ffi_navigator/dialect/__init__.py
+++ b/python/ffi_navigator/dialect/__init__.py
@@ -4,8 +4,33 @@ from .tvm import TVMProvider
 from .mxnet import MXNetProvider
 
 
+class NoOpProvider:
+    """A provider for projects without a registered dialect.
+    """
+    def __init__(self, resolver, logger):
+        self.resolver = resolver
+        self.logger = logger
+
+    def _cc_extract(self, path, source, begin, end):
+        return []
+
+    def _py_extract(self, path, source, begin, end):
+        return []
+
+    def init_pass(self, path, source):
+        pass
+
+    def extract(self, path, source, begin=0, end=None):
+        return []
+
+    def extract_symbol(self, path, source, pos):
+        return None
+
+
 def create_dialect(root_path, resolver, logger):
     if os.path.exists(os.path.join(root_path, "python", "tvm")):
         return TVMProvider(resolver, logger)
     elif os.path.exists(os.path.join(root_path, "python", "mxnet")):
         return MXNetProvider(resolver, logger)
+    else:
+        return NoOpProvider(resolver, logger)

--- a/python/ffi_navigator/dialect/__init__.py
+++ b/python/ffi_navigator/dialect/__init__.py
@@ -1,1 +1,3 @@
 """Namespace for FFI export dialects"""
+from .tvm import TVMProvider
+from .mxnet import MXNetProvider

--- a/python/ffi_navigator/dialect/__init__.py
+++ b/python/ffi_navigator/dialect/__init__.py
@@ -4,33 +4,23 @@ from .tvm import TVMProvider
 from .mxnet import MXNetProvider
 
 
-class NoOpProvider:
-    """A provider for projects without a registered dialect.
+def autodetect_dialects(root_path, resolver, logger):
+    """Auto-detects which providers to use based on the root path.
+
+    Parameters
+    ----------
+    resolver : PyImportResolver
+        Resolver for orginial definition.
+
+    logger : Logger object
+
+    Returns
+    -------
+    dialects: list of provider
     """
-    def __init__(self, resolver, logger):
-        self.resolver = resolver
-        self.logger = logger
-
-    def _cc_extract(self, path, source, begin, end):
-        return []
-
-    def _py_extract(self, path, source, begin, end):
-        return []
-
-    def init_pass(self, path, source):
-        pass
-
-    def extract(self, path, source, begin=0, end=None):
-        return []
-
-    def extract_symbol(self, path, source, pos):
-        return None
-
-
-def create_dialect(root_path, resolver, logger):
+    dialects = []
     if os.path.exists(os.path.join(root_path, "python", "tvm")):
-        return TVMProvider(resolver, logger)
+        dialects.append(TVMProvider(resolver, logger))
     elif os.path.exists(os.path.join(root_path, "python", "mxnet")):
-        return MXNetProvider(resolver, logger)
-    else:
-        return NoOpProvider(resolver, logger)
+        dialects.append(MXNetProvider(resolver, logger))
+    return dialects

--- a/python/ffi_navigator/dialect/__init__.py
+++ b/python/ffi_navigator/dialect/__init__.py
@@ -1,3 +1,11 @@
 """Namespace for FFI export dialects"""
+import os
 from .tvm import TVMProvider
 from .mxnet import MXNetProvider
+
+
+def create_dialect(root_path, resolver, logger):
+    if os.path.exists(os.path.join(root_path, "python", "tvm")):
+        return TVMProvider(resolver, logger)
+    elif os.path.exists(os.path.join(root_path, "python", "mxnet")):
+        return MXNetProvider(resolver, logger)

--- a/python/ffi_navigator/dialect/__init__.py
+++ b/python/ffi_navigator/dialect/__init__.py
@@ -9,6 +9,10 @@ def autodetect_dialects(root_path, resolver, logger):
 
     Parameters
     ----------
+    root_path: str
+        The root path for the project provided by a user or detected by
+        a LSP client
+
     resolver : PyImportResolver
         Resolver for orginial definition.
 

--- a/python/ffi_navigator/dialect/mxnet.py
+++ b/python/ffi_navigator/dialect/mxnet.py
@@ -1,0 +1,67 @@
+"""MXNet FFI convention"""
+import os
+from .. import pattern
+
+class MXNetProvider:
+    """Provider for MXNet FFI.
+
+    Parameters
+    ----------
+    resolver : PyImportResolver
+        Resolver for orginial definition.
+
+    logger : Logger object
+    """
+    def __init__(self, resolver, logger):
+        self.resolver = resolver
+        self.cc_c_api = pattern.re_matcher(
+            r"\s*int\s*(?P<key>MX[A-Za-z0-9]+)",
+            lambda match, path, rg:
+            pattern.Def(key=match.group("key"), path=path, range=rg))
+        self.py_lib = pattern.re_matcher(
+            r".*_LIB\.(?P<key>MX[A-Za-z0-9]+)",
+            lambda match, path, rg:
+            pattern.Ref(key=match.group("key"), path=path, range=rg))
+
+        self._pypath_root = None
+        self.logger = logger
+
+    def _cc_extract(self, path, source, begin, end):
+        if "c_api" in path:
+            return self.cc_c_api(path, source, begin, end)
+        return []
+
+    def _py_extract(self, path, source, begin, end):
+        results = self.py_lib(path, source, begin, end)
+        return results
+
+    def init_pass(self, path, source):
+        """This function will be called for each file before extract."""
+        if path.endswith("python/mxnet/__init__.py"):
+            self._pypath_root = os.path.abspath(path[:-len("/__init__.py")])
+            self.resolver.add_package("mxnet", self._pypath_root)
+            self.logger.info("MXNet: find python path %s", self._pypath_root)
+
+    def extract(self, path, source, begin=0, end=None):
+        """This function will be called for each file
+        Extract patterns in the file as specified in pattern.py and return them.
+        """
+        if path.endswith(".cc") or path.endswith(".h"):
+            return self._cc_extract(path, source, begin, end)
+        return []
+
+    def extract_symbol(self, path, source, pos):
+        """Extract possible pattern in the specified location, if not found, return None."""
+        # only search a small context
+        begin = max(pos.line - 1, 0)
+        end = min(pos.line + 2, len(source))
+        # We can use extract and verify to get the pattern.
+        if path.endswith(".py"):
+            for res in self._py_extract(path, source, begin, end):
+                if (isinstance(res, (pattern.Ref, pattern.Def)) and
+                    res.range.start.line <= pos.line and
+                    res.range.end.line >= pos.line and
+                    res.range.start.character <= pos.character and
+                    res.range.end.character >= pos.character):
+                    return res
+        return None

--- a/python/ffi_navigator/workspace.py
+++ b/python/ffi_navigator/workspace.py
@@ -3,7 +3,7 @@ import os
 import logging
 from . import pattern
 from .import_resolver import PyImportResolver
-from .dialect.tvm import TVMProvider
+from .dialect import TVMProvider, MXNetProvider
 
 def _append_dict(sdict, key, value):
     if key in sdict:

--- a/python/ffi_navigator/workspace.py
+++ b/python/ffi_navigator/workspace.py
@@ -3,7 +3,7 @@ import os
 import logging
 from . import pattern
 from .import_resolver import PyImportResolver
-from .dialect import create_dialect
+from .dialect import autodetect_dialects
 
 def _append_dict(sdict, key, value):
     if key in sdict:
@@ -28,8 +28,8 @@ class Workspace:
     def initialize(self, root_path):
         # By default only update root/src, root/python, root/include
         # can add configs later
-        self.logger.info("root_path: %s\n", root_path)
-        self._provider = create_dialect(root_path, self.pyimport_resolver, self.logger)
+        self.logger.info("root_path: %s", root_path)
+        self._providers = autodetect_dialects(root_path, self.pyimport_resolver, self.logger)
         self._root_path = root_path
         self._reload()
 
@@ -52,7 +52,8 @@ class Workspace:
         """Initialization pass"""
         mod_path = path[:-3] if path.endswith(".py") else path
         self.pyimport_resolver.update_doc(path, source)
-        self._provider.init_pass(path, source)
+        for provider in self._providers:
+            provider.init_pass(path, source)
 
     def update_dir(self, dirname):
         self.logger.info("Workspace.update_dir %s start", dirname)
@@ -69,16 +70,17 @@ class Workspace:
         self.logger.info("Workspace.update_dir %s finish", dirname)
 
     def update_doc(self, path, source):
-        for pt in self._provider.extract(path, source):
-            mod_path = path[:-3] if path.endswith(".py") else path
-            if isinstance(pt, pattern.Def):
-                _append_dict(self.key2defs, pt.key, pt)
-            elif isinstance(pt, pattern.Ref):
-                _append_dict(self.key2refs, pt.key, pt)
-            elif isinstance(pt, pattern.Export):
-                _append_dict(self.modpath2exports, mod_path, pt)
-            else:
-                self.logger.warn("Ignore pattern %s, path=%s", pt, path)
+        for provider in self._providers:
+            for pt in provider.extract(path, source):
+                mod_path = path[:-3] if path.endswith(".py") else path
+                if isinstance(pt, pattern.Def):
+                    _append_dict(self.key2defs, pt.key, pt)
+                elif isinstance(pt, pattern.Ref):
+                    _append_dict(self.key2refs, pt.key, pt)
+                elif isinstance(pt, pattern.Export):
+                    _append_dict(self.modpath2exports, mod_path, pt)
+                else:
+                    self.logger.warn("Ignore pattern %s, path=%s", pt, path)
         self.logger.debug("Workspace.update_doc %s", path)
 
     def find_defs(self, mod_path, sym_name):
@@ -139,7 +141,8 @@ class Workspace:
         return res
 
     def extract_symbol(self, path, source, pos):
-        res = self._provider.extract_symbol(path, source, pos)
-        if res:
-            return res
+        for pt in self._providers:
+            res = pt.extract_symbol(path, source, pos)
+            if res:
+                return res
         return pattern.extract_symbol(source, pos)


### PR DESCRIPTION

* Add an initial support for MXNet. It can jump from symbols such as _LIB.MXQuantizeSymbol in python file to its cpp definition in mxnet/src/c_api/

* Choose which dialect to use based on the provided root path. No config is required. I wasn't sure why having multiple providers is useful when working on a single project, so I removed the providers list and instantiate only one provider per opened file. It is still possible to visit files in TVM repo and switch to a  file in MXNet. The corresponding provider will be used for each file. We can discuss if this is a good approach @tqchen 

