### PR TITLE
Add goto definition support for Torch dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Most modern IDEs support find function definition within the same language(e.g. python or c++). However, it is very hard to do that for cross-language FFI calls. While solving this general problem can be very technically challenging, we can get around it by building a project-specific analyzer that matches the FFI registration code patterns and recovers the necessary information.
 
-This project is an example of that. Currently, it supports the PackedFunc FFI in the Apache TVM project. It is implemented as a [language server](https://microsoft.github.io/language-server-protocol/) that provides getDefinition function for FFI calls and returns the location of the corresponding C++ API in the TVM project. It complements the IDE tools that support navigation within the same language.
+This project is an example of that. Currently, it supports the PackedFunc FFI in the Apache TVM project. It is implemented as a [language server](https://microsoft.github.io/language-server-protocol/) that provides getDefinition function for FFI calls and returns the location of the corresponding C++ API in the TVM project. It complements the IDE tools that support navigation within the same language. We also have preliminary support for MXNet and PyTorch, so we can do goto-definition from Python to C++ in these projects too.
+
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Most modern IDEs support find function definition within the same language(e.g. python or c++). However, it is very hard to do that for cross-language FFI calls. While solving this general problem can be very technically challenging, we can get around it by building a project-specific analyzer that matches the FFI registration code patterns and recovers the necessary information.
 
-This project is an example of that. Currently, it supports the PackedFunc FFI in the Apache TVM project. It is implemented as a [language server](https://microsoft.github.io/language-server-protocol/) that provides getDefinition function for FFI calls and returns the location of the corresponding C++ API in the TVM project. It complements the IDE tools that support navigation within the same language. We also have preliminary support for MXNet and PyTorch, so we can do goto-definition from Python to C++ in these projects too.
+This project is an example of that. Currently, it supports the PackedFunc FFI in the Apache TVM project. It is implemented as a [language server](https://microsoft.github.io/language-server-protocol/) that provides getDefinition function for FFI calls and returns the location of the corresponding C++ API in the TVM project. It complements the IDE tools that support navigation within the same language. We also have preliminary support for MXNet, DGL, and PyTorch, so we can do goto-definition from Python to C++ in these projects too.
 
 
 ## Structure

--- a/python/ffi_navigator/dialect/dgl.py
+++ b/python/ffi_navigator/dialect/dgl.py
@@ -117,3 +117,6 @@ class DGLProvider:
                 res.range.end.character >= pos.character):
                 return res
         return None
+
+    def get_additional_scan_dirs(self, root_path):
+        return []

--- a/python/ffi_navigator/dialect/torch.py
+++ b/python/ffi_navigator/dialect/torch.py
@@ -7,30 +7,28 @@ from .. import pattern
 from ..lsp import Range, Position
 
 
-def _re_match_multi_line(pat, prefix, path, lines, logger):
+def _re_match_multi_line(pat, prefix, path, lines):
     source = "\n".join(lines)
-    matches = list(re.finditer(r"\.def\((?P<key_space>\s*)\"(?P<key_func>[a-z0-9|_]+)\"", source))
+    matches = list(re.finditer(pat, source))
     if matches == []:
         return []
-    line_count = len(lines)
     cumsum = np.cumsum(list(map(lambda line: len(line)+1, lines))) # +1 for newline
 
     next_begin = 0
     result = []
     # find line num, start and end pos for each match
     for match in matches:
-        line_num = bisect(cumsum[next_begin:], match.start()) + next_begin
+        line_num = int(bisect(cumsum[next_begin:], match.start())) + next_begin
         next_begin = line_num
         line_num_start = line_num
         line_num_end = line_num
         if match.group("key_space"):
             line_num_end += 1
-        pos_start = match.start() - cumsum[line_num_start-1]
-        pos_end = match.end() - cumsum[line_num_end-1]
+        pos_start = match.start() - int(cumsum[line_num_start-1])
+        pos_end = match.end() - int(cumsum[line_num_end-1])
         rg = Range(Position(line_num_start, pos_start), Position(line_num_end, pos_end))
         key = prefix + match.group("key_func")
         result.append(pattern.Def(key=key, path=path, range=rg))
-        logger.info("key=%s, line_num=%d, span=(%d, %d)", key, line_num, match.start(), match.end())
 
     return result
 
@@ -60,7 +58,7 @@ class TorchProvider:
             pattern.Def(key=match.group("key"), path=path, range=rg),
             use_search=True)
         self.cpp_pybind_func = lambda path, lines: \
-          _re_match_multi_line(r"\.def\(\s*\"(?P<key_func>[a-z0-9|_]+)\"", "", path, lines, self.logger)
+          _re_match_multi_line(r"\.def\((?P<key_space>\s*)\"(?P<key_func>[a-z0-9|_]+)\"", "", path, lines)
         self.py_ops = pattern.re_matcher(
             r"ops\.(?P<key_namespace>[a-z0-9|_|]+)\.(?P<key_op>[a-z0-9|_|]+)",
             lambda match, path, rg:
@@ -73,7 +71,6 @@ class TorchProvider:
             pattern.Ref(key=match.group("key_op"),
                         path=path, range=rg),
             use_search=True)
-                    # torch._C._jit_pass_inline(mod_canonicalized)
         self.py_pybind_func = pattern.re_matcher(
             r"torch\._C\.(?P<key_func>[a-z0-9|_]+)",
             lambda match, path, rg:
@@ -92,8 +89,6 @@ class TorchProvider:
         for generated in generated_cpp:
             if path.endswith(generated):
                 results += self.cpp_generated(path, source, begin, end)
-        for res in results:
-            self.logger.info("Extracted %s from %s, range=%s", res.key, res.path, res.range)
         return results
 
     def _py_extract(self, path, source, begin, end):
@@ -101,8 +96,6 @@ class TorchProvider:
         results += self.py_ops(path, source, begin, end)
         results += self.py_variable_methods(path, source, begin, end)
         results += self.py_pybind_func(path, source, begin, end)
-        for res in results:
-            self.logger.info("Py: Extracted %s from %s", res.key, res.path)
 
         return results
 

--- a/python/ffi_navigator/dialect/torch.py
+++ b/python/ffi_navigator/dialect/torch.py
@@ -75,13 +75,17 @@ class TorchProvider:
         #     "_jit_pass_insert_prepack_unpack",
         #     [](script::Module& module) { return InsertPrepackUnpack(module); })
         self.cpp_pybind_func = lambda path, lines: \
-          _re_match_multi_line(r"\.def\((?P<key_space>\s*)\"(?P<key>[a-z0-9|_]+)\"", path, lines)
+          _re_match_multi_line(r"\.def\((?P<key_space>\s*)\"(?P<key>[a-z0-9|_]+)\"",
+                               path, lines)
         # A pattern for pybind-wrapped classes
         # py::class_<Method>(m, "ScriptMethod", py::dynamic_attr())
         # py::class_<CompilationUnit, std::shared_ptr<CompilationUnit>>(
         #     m, "CompilationUnit")
         self.cpp_pybind_class = lambda path, lines: \
-          _re_match_multi_line("py::class_\<[A-Za-z0-9|_|::|<|>]+(\,\s*[A-Za-z0-9|_|::|<|>]+)*\>\s*\((?P<key_space>\s*)m,\s*\"(?P<key>[A-Za-z0-9|_]+)\"(,\s*[A-Za-z0-9|_|::|<|>|(|)]+)*\)", path, lines)
+          _re_match_multi_line(r"py::class_\<[A-Za-z0-9|_|::|<|>]+(\,\s*[A-Za-z0-9|_|::|<|>]+)*\>"
+                               r"\s*\((?P<key_space>\s*)m,\s*\"(?P<key>[A-Za-z0-9|_]+)\""
+                               r"(,\s*[A-Za-z0-9|_|::|<|>|(|)]+)*\)",
+                               path, lines)
         # torch.ops.quantized.conv2d_relu (c10 ops)
         self.py_ops = pattern.re_matcher(
             r"ops\.(?P<key_namespace>[a-z0-9|_|]+)\.(?P<key_op>[a-z0-9|_|]+)",

--- a/python/ffi_navigator/dialect/torch.py
+++ b/python/ffi_navigator/dialect/torch.py
@@ -63,7 +63,7 @@ class TorchProvider:
         # {"conv2d", (PyCFunction)(void(*)(void))THPVariable_conv2d, ...
         # {"conv3d", (PyCFunction)(void(*)(void))THPVariable_conv3d, ...
         self.cpp_generated = pattern.re_matcher(
-            r"{\"(?P<key>[a-z0-9|_|::]+)\"",
+            r"{\"(?P<key>[a-z0-9|_]+)\"",
             lambda match, path, rg:
             pattern.Def(key=match.group("key"), path=path, range=rg),
             use_search=True)
@@ -71,9 +71,6 @@ class TorchProvider:
         # .def(
         #     "_jit_pass_insert_prepack_unpack",
         #     [](std::shared_ptr<Graph>& g) { return InsertPrepackUnpack(g); })
-        # .def(
-        #     "_jit_pass_insert_prepack_unpack",
-        #     [](script::Module& module) { return InsertPrepackUnpack(module); })
         self.cpp_pybind_func = lambda path, lines: \
           _re_match_multi_line(r"\.def\((?P<key_space>\s*)\"(?P<key>[a-z0-9|_]+)\"",
                                path, lines)


### PR DESCRIPTION
Added support for goto definition from python to cpp in PyTorch, in roughly three categories (which I think should cover mose use cases) below. Tested on emacs with both lsp-mode and eglot.

* C10 registered ops. In python they corresponds to functions under "torch.ops" namespace. Example:  torch.ops.quantized.conv2d (py) ->  c10::RegisterOperators().op("quantized::conv2d", ...) (cpp, https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/quantized/cpu/qconv.cpp#L641)

* Basic tensor methods under "torch" namespace such as torch.conv2d(), torch.cat(), torch.unsqueeze() etc. Their cpp definitions are automatically generated under csrc/autograd/generated during building from source, so for this case to work, source build is required.

* Jump to cpp functions wrapped by pybind. Example: torch._C._jit_script_class_compile (py) ->   m.def(     "_jit_script_class_compile", ...) (cpp, https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/script/init.cpp#L1008). Jumping to pybind-wrapped cpp classes also works, so you can jump from torch._C.ScriptFunction in python to its definition in csrc/jit/script/init.cpp. My regexp cannot distinguish member functions of pybind-wrapped classes from pybind-wrapped free functions, so you cannot jump to member functions at the moment.

See the commented regex patterns for more examples. My regex knowledge is very rusty, so suggestions for improvement are welcome :)
