### PR TITLE
Fix newline handling in multi line regex matching

### DIFF
--- a/python/ffi_navigator/pattern.py
+++ b/python/ffi_navigator/pattern.py
@@ -132,11 +132,11 @@ def re_multi_line_matcher(rexpr, fcreate):
     rexpr = re.compile(rexpr)
 
     def _matcher(path, lines):
-        source = "\n".join(lines)
+        source = "".join(lines)
         matches = list(rexpr.finditer(source))
         if matches == []:
             return []
-        line_counts = map(lambda line: len(line)+1, lines) # +1 for newline
+        line_counts = map(lambda line: len(line), lines)
         cumsum = np.cumsum(list(line_counts))
 
         # find line num, start and end pos for each match
@@ -148,6 +148,7 @@ def re_multi_line_matcher(rexpr, fcreate):
             line_num_end = line_num_start + match.group().count("\n")
             pos_start = match.start() - int(cumsum[line_num_start-1])
             pos_end = match.end() - int(cumsum[line_num_end-1])
+            assert(pos_start >= 0 and pos_end >= 0)
             rg = Range(Position(line_num_start, pos_start), Position(line_num_end, pos_end))
             result.append(fcreate(match, path, rg))
 

--- a/tests/python/test_langserver.py
+++ b/tests/python/test_langserver.py
@@ -82,6 +82,14 @@ def test_torch_dialect(pytorch_path):
     assert(res[0]['range']['start']['line'] == 95)
 
     res = run_find_definition(server,
+                              os.path.join(pytorch_path, "torch/jit/__init__.py"),
+                              25, 30)
+    assert(len(res) > 0)
+    assert(res[0]['uri'].endswith("init.cpp"))
+    assert(res[0]['range']['start']['line'] == 1)
+    assert(res[0]['range']['end']['character'] == 27)
+
+    res = run_find_definition(server,
                               os.path.join(pytorch_path, "torch/nn/functional.py"),
                               16, 30)
     assert(len(res) > 0)


### PR DESCRIPTION
When refactoring multi line regex matching, I introduced a bug where pos_end can become negative.
This value doesn't affect navigation, but I do get warning from my LSP client saying one of the returned value is negative.

The problem was that I was making a wrong assumption that open(path).readlines() would remove a newline at the end of each line. This was fixed in this PR.

@tqchen we may want to release a new version on pypi.