### PR TITLE
Add configuration to set the path of python

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,6 +1,6 @@
 # VS Code Extension for FFI Navigator
 
-VSCode extension for ffi nagivator.
+VSCode extension for ffi navigator.
 
 ### Demo
 
@@ -50,4 +50,4 @@ NOTE: You only need to reinstall the extension when the client side change.
 
 ## Debug information from python package
 
-- You can select output tab in the terminal bar, and select `FFI Nagivator` to see logs from the python side
+- You can select output tab in the terminal bar, and select `FFI Navigator` to see logs from the python side

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -19,7 +19,19 @@
 		"onLanguage:plaintext"
 	],
 	"main": "./out/extension",
-	"contributes": {},
+	"contributes": {
+		"configuration": {
+			"title": "FFINavigator",
+			"properties": {
+				"ffi_navigator.pythonpath": {
+					"type": "string",
+					"default": "python",
+					"scope": "machine-overridable",
+					"description": "Python path which installed the ffi language server, i.e. '/usr/bin/python'"
+				}
+			}
+		}
+	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -b",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  * ------------------------------------------------------------------------------------------ */
-import { ExtensionContext, window } from 'vscode';
+import { ExtensionContext, window, workspace } from 'vscode';
 import { execSync } from 'child_process';
 
 import {
@@ -23,8 +23,8 @@ export function activate(context: ExtensionContext) {
                                 ' Please run "pip3 install ffi_navigator" and reload the window');
         return ;
     }
-    const config = vscode.workspace.getConfiguration('')
-    let pyCommand = config.get("ffi_navigator.pythonpath")
+    const config = workspace.getConfiguration('')
+    let pyCommand = config.get("ffi_navigator.pythonpath", "python")
     let args = ['-m', 'ffi_navigator.langserver']
     let commandOptions: ExecutableOptions = { stdio: 'pipe', detached: false };
     let serverOptions: ServerOptions = {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -23,8 +23,8 @@ export function activate(context: ExtensionContext) {
                                 ' Please run "pip3 install ffi_navigator" and reload the window');
         return ;
     }
-
-    let pyCommand = 'python3'
+    const config = vscode.workspace.getConfiguration('')
+    let pyCommand = config.get("ffi_navigator.pythonpath")
     let args = ['-m', 'ffi_navigator.langserver']
     let commandOptions: ExecutableOptions = { stdio: 'pipe', detached: false };
     let serverOptions: ServerOptions = {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,16 +15,16 @@ import {
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
+    const config = workspace.getConfiguration('')
+    let pyCommand = config.get("ffi_navigator.pythonpath", "python")
     // Check if the Python package is installed.
     try {
-        execSync("pip3 show ffi_navigator");
+        execSync(`${pyCommand} -m pip show ffi_navigator`);
     } catch (error) {
         window.showErrorMessage('ffi_navigator is not installed.' +
                                 ' Please run "pip3 install ffi_navigator" and reload the window');
         return ;
     }
-    const config = workspace.getConfiguration('')
-    let pyCommand = config.get("ffi_navigator.pythonpath", "python")
     let args = ['-m', 'ffi_navigator.langserver']
     let commandOptions: ExecutableOptions = { stdio: 'pipe', detached: false };
     let serverOptions: ServerOptions = {


### PR DESCRIPTION
Since many people using virtual environment management tool for python such as anaconda, pyenv or virtualenv. User may want to specify which python has installed ffi-navigator.