### PR TITLE
[Torch] Add support for more patterns

### DIFF
--- a/python/ffi_navigator/dialect/torch.py
+++ b/python/ffi_navigator/dialect/torch.py
@@ -104,7 +104,9 @@ class TorchProvider(BaseProvider):
         results = self.c10_reg(path, source, begin, end)
         results += self.cpp_pybind_func(path, source)
         results += self.cpp_pybind_class(path, source)
-        results += self.cpp_py_method_def(path, source, begin, end)
+
+        if "PyMethodDef" in "".join(source):
+            results += self.cpp_py_method_def(path, source, begin, end)
 
         return results
 

--- a/python/ffi_navigator/dialect/torch.py
+++ b/python/ffi_navigator/dialect/torch.py
@@ -73,6 +73,14 @@ class TorchProvider(BaseProvider):
                         path=path, range=rg),
             use_search=True)
 
+        # module._c._create_method_from_trace
+        self.py_wrapped_method = pattern.re_matcher(
+            r"[A-Za-z0-9|_]+\._c\.(?P<key>[A-Za-z0-9|_|]+)",
+            lambda match, path, rg:
+            pattern.Ref(key=match.group("key"),
+                        path=path, range=rg),
+            use_search=True)
+
     def get_additional_scan_dirs(self, root_path):
         return [
             os.path.join(root_path, "aten", "src", "ATen"),
@@ -96,6 +104,7 @@ class TorchProvider(BaseProvider):
     def _py_extract(self, path, source, begin, end):
         results = self.py_ops(path, source, begin, end)
         results += self.py_wrapped(path, source, begin, end)
+        results += self.py_wrapped_method(path, source, begin, end)
         return results
 
     def extract(self, path, source, begin=0, end=None):

--- a/python/ffi_navigator/dialect/torch.py
+++ b/python/ffi_navigator/dialect/torch.py
@@ -28,13 +28,17 @@ class TorchProvider(BaseProvider):
             lambda match, path, rg:
             pattern.Def(key=match.group("key"), path=path, range=rg),
             use_search=True)
-        # A pattern for generated methods under torch/csrc/autograd/generated
-        # You need to have built PyTorch from source for this pattern to work
-        # {"conv1d", (PyCFunction)(void(*)(void))THPVariable_conv1d, ...
+        # C extensions wrapped via PyMethodDef (not pybind)
+        # static struct PyMethodDef THPFunction_methods[] = {
+        #   {(char*)"_do_forward", (PyCFunction)THPFunction_do_forward, METH_VARARGS, nullptr},
+        #   {(char*)"_do_backward", (PyCFunction)THPFunction_do_backward, METH_VARARGS, nullptr},
+        #   {nullptr}
+        # };
+        # This also includes pattern for generated methods under torch/csrc/autograd/generated
+        # If you have PyTorch built from source, you can jump to the generated function, for example
         # {"conv2d", (PyCFunction)(void(*)(void))THPVariable_conv2d, ...
-        # {"conv3d", (PyCFunction)(void(*)(void))THPVariable_conv3d, ...
-        self.cpp_generated = pattern.re_matcher(
-            r"{\"(?P<key>[a-z0-9|_]+)\"",
+        self.cpp_py_method_def = pattern.re_matcher(
+            r"{(\(char\*\))?\"(?P<key>[a-z0-9|_]+)\"",
             lambda match, path, rg:
             pattern.Def(key=match.group("key"), path=path, range=rg),
             use_search=True)
@@ -66,8 +70,9 @@ class TorchProvider(BaseProvider):
         # torch.conv1d, torch._C._nn.avg_pool2d (variable methods)
         # torch._C._jit_script_class_compile (for jit etc)
         # torch._C.ScriptMethod, torch._C.CompilationUnit
+        # _C._FunctionBase._do_forward, _C._TensorBase.detach
         self.py_wrapped = pattern.re_matcher(
-            r"torch\.([A-Za-z0-9|_]+\.)*(?P<key>[A-Za-z0-9|_|]+)",
+            r"(torch)?\.([A-Za-z0-9|_]+\.)*(?P<key>[A-Za-z0-9|_|]+)",
             lambda match, path, rg:
             pattern.Ref(key=match.group("key"),
                         path=path, range=rg),
@@ -88,17 +93,19 @@ class TorchProvider(BaseProvider):
         ]
 
     def _cc_extract(self, path, source, begin, end):
-        results = self.c10_reg(path, source, begin, end)
-        results += self.cpp_pybind_func(path, source)
-        results += self.cpp_pybind_class(path, source)
         generated_cpp = [
              os.path.join("generated", "python_nn_functions.cpp"),
              os.path.join("generated", "python_torch_functions.cpp"),
              os.path.join("generated", "python_variable_methods.cpp")
         ]
-        for generated in generated_cpp:
-            if path.endswith(generated):
-                results += self.cpp_generated(path, source, begin, end)
+        if any(path.endswith(generated) for generated in generated_cpp):
+            return self.cpp_py_method_def(path, source, begin, end)
+
+        results = self.c10_reg(path, source, begin, end)
+        results += self.cpp_pybind_func(path, source)
+        results += self.cpp_pybind_class(path, source)
+        results += self.cpp_py_method_def(path, source, begin, end)
+
         return results
 
     def _py_extract(self, path, source, begin, end):

--- a/tests/dummy_repo/pytorch/torch/autograd/__init__.py
+++ b/tests/dummy_repo/pytorch/torch/autograd/__init__.py
@@ -1,0 +1,27 @@
+import torch
+import warnings
+
+from .variable import Variable
+from .function import Function, NestedIOFunction
+from .gradcheck import gradcheck, gradgradcheck
+from .grad_mode import no_grad, enable_grad, set_grad_enabled
+from .anomaly_mode import detect_anomaly, set_detect_anomaly
+from . import profiler
+
+
+def backward(tensors, grad_tensors=None, retain_graph=None, create_graph=False, grad_variables=None):
+    tensors = (tensors,) if isinstance(tensors, torch.Tensor) else tuple(tensors)
+    if grad_tensors is None:
+        grad_tensors = [None] * len(tensors)
+    elif isinstance(grad_tensors, torch.Tensor):
+        grad_tensors = [grad_tensors]
+    else:
+        grad_tensors = list(grad_tensors)
+
+    grad_tensors = _make_grads(tensors, grad_tensors)
+    if retain_graph is None:
+        retain_graph = create_graph
+
+    Variable._execution_engine.run_backward(
+        tensors, grad_tensors, retain_graph, create_graph,
+        allow_unreachable=True)  # allow_unreachable flag

--- a/tests/dummy_repo/pytorch/torch/autograd/function.py
+++ b/tests/dummy_repo/pytorch/torch/autograd/function.py
@@ -1,0 +1,6 @@
+import torch
+import torch._C as _C
+
+
+class Function(with_metaclass(FunctionMeta, _C._FunctionBase, _ContextMethodMixin, _HookMixin)):
+    __call__ = _C._FunctionBase._do_forward

--- a/tests/dummy_repo/pytorch/torch/backends/quantized/__init__.py
+++ b/tests/dummy_repo/pytorch/torch/backends/quantized/__init__.py
@@ -1,0 +1,18 @@
+import sys
+import torch
+import types
+
+class _QEngineProp(object):
+    def __get__(self, obj, objtype):
+        return _get_qengine_str(torch._C._get_qengine())
+
+    def __set__(self, obj, val):
+        torch._C._set_qengine(_get_qengine_id(val))
+
+class _SupportedQEnginesProp(object):
+    def __get__(self, obj, objtype):
+        qengines = torch._C._supported_qengines()
+        return [_get_qengine_str(qe) for qe in qengines]
+
+    def __set__(self, obj, val):
+        raise RuntimeError("Assignment not supported")

--- a/tests/dummy_repo/pytorch/torch/csrc/Module.cpp
+++ b/tests/dummy_repo/pytorch/torch/csrc/Module.cpp
@@ -1,0 +1,51 @@
+#include <torch/csrc/python_headers.h>
+#include <sys/types.h>
+#include <unordered_map>
+#include <cstdlib>
+#include <libshm.h>
+#include <TH/TH.h>
+#include <c10/util/Logging.h>
+#include <ATen/ATen.h>
+#include <ATen/ExpandUtils.h>
+#include <ATen/dlpack.h>
+#include <ATen/DLConvertor.h>
+#include <ATen/Parallel.h>
+#include <ATen/Utils.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+PyObject *THPModule_setQEngine(PyObject */* unused */, PyObject *arg)
+{
+  THPUtils_assert(THPUtils_checkLong(arg), "set_qengine expects an int, "
+          "but got %s", THPUtils_typename(arg));
+  auto qengine = static_cast<int>(THPUtils_unpackLong(arg));
+  at::globalContext().setQEngine(static_cast<at::QEngine>(qengine));
+  Py_RETURN_NONE;
+}
+
+PyObject *THPModule_qEngine(PyObject */* unused */)
+{
+  return THPUtils_packInt64(static_cast<int>(at::globalContext().qEngine()));
+}
+
+PyObject *THPModule_supportedQEngines(PyObject */* unused */)
+{
+  auto qengines = at::globalContext().supportedQEngines();
+  auto list = THPObjectPtr(PyList_New(qengines.size()));
+  for (size_t i = 0; i < qengines.size(); ++i) {
+    PyObject *i64 = THPUtils_packInt64(static_cast<int>(qengines[i]));
+    if (!i64) {
+      throw python_error();
+    }
+    PyList_SET_ITEM(list.get(), i, i64);
+  }
+  return list.release();
+}
+
+//NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
+static PyMethodDef TorchMethods[] = {
+  {"_get_qengine", (PyCFunction)THPModule_qEngine, METH_NOARGS, nullptr},
+  {"_set_qengine", (PyCFunction)THPModule_setQEngine, METH_O, nullptr},
+  {"_supported_qengines", (PyCFunction)THPModule_supportedQEngines, METH_NOARGS, nullptr},
+  {nullptr, nullptr, 0, nullptr}
+};

--- a/tests/dummy_repo/pytorch/torch/csrc/autograd/python_engine.cpp
+++ b/tests/dummy_repo/pytorch/torch/csrc/autograd/python_engine.cpp
@@ -1,0 +1,18 @@
+#include <torch/csrc/autograd/python_engine.h>
+#include <torch/csrc/DynamicTypes.h>
+#include <torch/csrc/PtrWrapper.h>
+#include <torch/csrc/THP.h>
+#include <torch/csrc/autograd/edge.h>
+#include <torch/csrc/autograd/engine.h>
+#include <torch/csrc/autograd/function.h>
+#include <torch/csrc/autograd/python_anomaly_mode.h>
+#include <torch/csrc/autograd/python_function.h>
+#include <pybind11/pybind11.h>
+
+
+static struct PyMethodDef THPEngine_methods[] = {
+  {(char*)"run_backward", (PyCFunction)(void(*)(void))THPEngine_run_backward, METH_VARARGS | METH_KEYWORDS, nullptr},
+  {(char*)"queue_callback", (PyCFunction)THPEngine_queue_callback, METH_O, nullptr},
+  {(char*)"is_checkpoint_valid", (PyCFunction)THPEngine_is_checkpoint_valid, METH_NOARGS, nullptr},
+  {nullptr}
+};

--- a/tests/dummy_repo/pytorch/torch/csrc/autograd/python_function.cpp
+++ b/tests/dummy_repo/pytorch/torch/csrc/autograd/python_function.cpp
@@ -1,0 +1,17 @@
+#include <torch/csrc/autograd/python_function.h>
+#include <torch/csrc/python_headers.h>
+#include <structmember.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <exception>
+#include <ATen/ATen.h>
+
+
+static struct PyMethodDef THPFunction_methods[] = {
+  {(char*)"apply", (PyCFunction)THPFunction_apply, METH_CLASS | METH_VARARGS, nullptr},
+  {(char*)"_do_forward", (PyCFunction)THPFunction_do_forward, METH_VARARGS, nullptr},
+  {(char*)"_do_backward", (PyCFunction)THPFunction_do_backward, METH_VARARGS, nullptr},
+  {(char*)"_register_hook_dict", (PyCFunction)THPFunction__register_hook_dict, METH_O, nullptr},
+  {(char*)"register_hook", (PyCFunction)THPFunction_register_hook, METH_O, nullptr},
+  {nullptr}
+};

--- a/tests/dummy_repo/pytorch/torch/csrc/jit/init.cpp
+++ b/tests/dummy_repo/pytorch/torch/csrc/jit/init.cpp
@@ -17,80 +17,111 @@ void initJitScriptBindings(PyObject* module) {
             cu.define(c10::nullopt, src, pythonResolver(rcb), nullptr);
           });
 
-  py::class_<StrongFunctionPtr>(m, "ScriptFunction", py::dynamic_attr())
+  py::class_<Object>(m, "ScriptObject")
+      .def("_type", [](Module& m) { return m.type(); })
       .def(
-          "__call__",
-          [](py::args args, py::kwargs kwargs) {
-            HANDLE_TH_ERRORS
-            // see: [pybind11 varargs]
-            auto strongPtr = py::cast<StrongFunctionPtr>(args[0]);
-            Function& callee = *strongPtr.function_;
-            bool tracing = tracer::isTracing();
-            py::object result = invokeScriptFunctionFromPython(
-                callee, tuple_slice(std::move(args), 1), std::move(kwargs));
-            return result;
-            END_HANDLE_TH_ERRORS_PYBIND
+          "_get_method",
+          [](Object& self, const std::string& name) -> Method {
+            return self.get_method(name);
+          },
+          py::keep_alive<0, 1>())
+      .def(
+          "setattr",
+          [](Object& self, const std::string& name, py::object value) {
+            if (self.type()->hasConstant(name)) {
+              TORCH_CHECK(
+                  false,
+                  "Can't set constant '",
+                  name,
+                  "' which has value:",
+                  self.type()->getConstant(name));
+            }
+            TypePtr type = self.type()->getAttribute(name);
+            auto ivalue = toIValue(std::move(value), type);
+            self.setattr(name, ivalue);
           })
       .def(
+          "getattr",
+          [](Object& self, const std::string& name) {
+            return toPyObject(self.attr(name));
+          })
+      .def(
+          "__getattr__",
+          [](Object& self, const std::string& name) {
+            if (auto method = self.find_method(name)) {
+              return py::cast(*method);
+            }
+            return toPyObject(self.attr(name));
+          })
+      .def(
+          "hasattr",
+          [](Object& self, const std::string& name) {
+            return self.hasattr(name);
+          })
+      .def(
+          "_has_method",
+          [](Object& self, const std::string& name) {
+            return bool(self.find_method(name));
+          })
+
+  py::class_<Module, Object>(m, "ScriptModule")
+      .def(py::init<std::string, std::shared_ptr<CompilationUnit>, bool>())
+      .def(
           "save",
-          [](const StrongFunctionPtr& self,
+          [](Module& m,
              const std::string& filename,
              const ExtraFilesMap& _extra_files = ExtraFilesMap()) {
-            Module module("__torch__.PlaceholderModule");
-            // [issue 27343]
-            // Modules have 'training' attributes by defualt, but due to
-            // https://github.com/pytorch/pytorch/issues/27343, functions end
-            // up having a training attribute when they are loaded. This adds
-            // a fake 'training' attribute that shouldn't be used, but prevents
-            // jitter on saving and loading. Once that issue is fixed this can
-            // be deleted.
-            module.register_attribute("training", BoolType::get(), true);
-            addFunctionToModule(module, self);
-            module.save(filename, _extra_files);
+            m.save(filename, _extra_files);
           },
           py::arg("filename"),
           py::arg("_extra_files") = ExtraFilesMap())
       .def(
           "save_to_buffer",
-          [](const StrongFunctionPtr& self,
-             const ExtraFilesMap& _extra_files = ExtraFilesMap()) {
+          [](Module& m, const ExtraFilesMap& _extra_files = ExtraFilesMap()) {
             std::ostringstream buf;
-            Module module("__torch__.PlaceholderModule");
-            // see [issue 27343]
-            module.register_attribute("training", BoolType::get(), true);
-            addFunctionToModule(module, self);
-            module.save(buf, _extra_files);
+            m.save(buf, _extra_files);
             return py::bytes(buf.str());
           },
           py::arg("_extra_files") = ExtraFilesMap())
-      .def_property_readonly(
-          "graph",
-          [](const StrongFunctionPtr& self) { return self.function_->graph(); })
-      .def_property_readonly(
-          "schema",
-          [](const StrongFunctionPtr& self) {
-            return self.function_->getSchema();
-          })
-      .def_property_readonly(
-          "code",
-          [](const StrongFunctionPtr& self) {
-            std::vector<at::Tensor> tensors;
-            std::vector<c10::NamedTypePtr> deps;
-            PythonPrint pp(tensors, deps, false);
-            pp.printFunction(*self.function_);
-            return pp.str();
-          })
       .def(
           "get_debug_state",
-          [](const StrongFunctionPtr& self) {
-            return self.function_->get_executor().getDebugState();
+          [](Module& self) {
+            if (auto m = self.find_method("forward")) {
+              return m->get_executor().getDebugState();
+            }
+            throw std::runtime_error(
+                "Attempted to call get_debug_state on a Module without a compiled forward()");
           })
-      .def_property_readonly(
-          "name",
-          [](const StrongFunctionPtr& self) { return self.function_->name(); })
-      .def_property_readonly(
-          "qualified_name", [](const StrongFunctionPtr& self) {
-            return self.function_->qualname().qualifiedName();
+      .def(
+          "_define",
+          [](Module& m,
+             std::shared_ptr<ConcreteModuleType> concreteType,
+             const std::string& script,
+             ResolutionCallback rcb) {
+            const auto self = ModuleSelf(std::move(concreteType));
+            m._ivalue()->compilation_unit()->define(
+                *m.type()->name(), script, pythonResolver(rcb), &self);
+            didFinishEmitModule(m);
+          })
+      .def(
+          "_create_method_from_trace",
+          [](Module& self,
+             const std::string& name,
+             py::function func,
+             py::tuple input_tuple,
+             py::function var_lookup_fn,
+             bool force_outplace) {
+            // prereq: Module's buffers and parameters are unique
+            // this was ensured in python before calling this function
+            auto typed_inputs = toTraceableStack(input_tuple);
+
+            std::shared_ptr<Graph> graph = std::get<0>(tracer::createGraphByTracing(
+                func, typed_inputs, var_lookup_fn, force_outplace, &self));
+            const auto method_name = QualifiedName(*self.type()->name(), name);
+            auto fn = self._ivalue()->compilation_unit()->create_function(
+                method_name, graph);
+            self.type()->addMethod(fn);
+            didFinishEmitModule(self);
           });
 
   m.def("_jit_script_class_compile", [](const std::string &qualifiedName,
@@ -121,26 +152,4 @@ void initJitScriptBindings(PyObject* module) {
     cu->define(classname, methodDefs, rcbs, &self);
   });
 
-  py::class_<Module, Object>(m, "ScriptModule")
-      .def(py::init<std::string, std::shared_ptr<CompilationUnit>, bool>())
-      .def(
-          "_create_method_from_trace",
-          [](Module& self,
-             const std::string& name,
-             py::function func,
-             py::tuple input_tuple,
-             py::function var_lookup_fn,
-             bool force_outplace) {
-            // prereq: Module's buffers and parameters are unique
-            // this was ensured in python before calling this function
-            auto typed_inputs = toTraceableStack(input_tuple);
-
-            std::shared_ptr<Graph> graph = std::get<0>(tracer::createGraphByTracing(
-                func, typed_inputs, var_lookup_fn, force_outplace, &self));
-            const auto method_name = QualifiedName(*self.type()->name(), name);
-            auto fn = self._ivalue()->compilation_unit()->create_function(
-                method_name, graph);
-            self.type()->addMethod(fn);
-            didFinishEmitModule(self);
-          });
 }

--- a/tests/dummy_repo/pytorch/torch/jit/__init__.py
+++ b/tests/dummy_repo/pytorch/torch/jit/__init__.py
@@ -29,3 +29,61 @@ Future = torch._C.Future
 set_module(Future, "torch.jit")
 _fork = torch._C.fork
 _wait = torch._C.wait
+
+
+def trace_module(mod,
+                 inputs,
+                 optimize=None,
+                 check_trace=True,
+                 check_inputs=None,
+                 check_tolerance=1e-5,
+                 _force_outplace=False,
+                 _module_class=None,
+                 _compilation_unit=_python_cu):
+    if not _enabled:
+        return mod
+    if optimize is not None:
+        warnings.warn("`optimize` is deprecated and has no effect. Use `with torch.jit.optimized_execution() instead")
+
+    var_lookup_fn = _create_interpreter_name_lookup_fn(0)
+
+    if not isinstance(mod, torch.nn.Module):
+        raise AttributeError("expected torch.nn.Module as the first argument")
+
+    if not isinstance(inputs, dict):
+        raise AttributeError("expected a dictionary of (method_name, input) pairs")
+
+    old_module_map = torch.jit._trace_module_map
+    try:
+        torch.jit._trace_module_map = {}
+
+        def register_submods(mod, prefix):
+            for name, child in mod.named_children():
+                submod_qualname = prefix + '.' + name
+                torch.jit._trace_module_map[child] = submod_qualname
+                register_submods(child, submod_qualname)
+
+        torch.jit._trace_module_map['__module'] = mod
+        register_submods(mod, '__module')
+
+        module = make_module(mod, _module_class, _compilation_unit)
+
+        for method_name, example_inputs in inputs.items():
+            # this is needed since Module.__call__ sets up some extra tracing
+            func = mod if method_name == "forward" else getattr(mod, method_name)
+            example_inputs = make_tuple(example_inputs)
+            module._c._create_method_from_trace(method_name, func, example_inputs, var_lookup_fn, _force_outplace)
+            check_trace_method = module._c._get_method(method_name)
+
+            # Check the trace against new traces created from user-specified inputs
+            if check_trace:
+                if check_inputs is not None:
+                    _check_trace(check_inputs, func, check_trace_method,
+                                 check_tolerance, _force_outplace, True, _module_class)
+                else:
+                    _check_trace([inputs], func, check_trace_method,
+                                 check_tolerance, _force_outplace, True, _module_class)
+    finally:
+        torch.jit._trace_module_map = old_module_map
+
+    return module

--- a/tests/python/test_langserver.py
+++ b/tests/python/test_langserver.py
@@ -336,7 +336,7 @@ def test_dgl_dialect():
 if __name__ == "__main__":
     # eyeballing test script
     logging.basicConfig(level=logging.INFO, format="[%(asctime)-15s] %(message)s")
-    # test_tvm_dialect()
+    test_tvm_dialect()
     test_torch_dialect()
-    # test_mxnet_dialect()
-    # test_dgl_dialect()
+    test_mxnet_dialect()
+    test_dgl_dialect()

--- a/tests/python/test_langserver.py
+++ b/tests/python/test_langserver.py
@@ -250,6 +250,14 @@ def test_torch_dialect():
     assert(res[0]['uri'].endswith("python_torch_functions.cpp"))
     assert(res[0]['range']['start']['line'] == 2)
 
+    # module._c._create_method_from_trace
+    res = run_find_definition(server,
+                              join_path(pytorch_path, "torch/jit/__init__.py"),
+                              74, 30)
+    assert(len(res) > 0)
+    assert(res[0]['uri'].endswith("init.cpp"))
+    assert(res[0]['range']['start']['line'] == 125)
+
 
 def test_mxnet_dialect():
     mx_path = os.path.join(curr_path, "..", "dummy_repo", "mxnet")

--- a/tests/python/test_langserver.py
+++ b/tests/python/test_langserver.py
@@ -280,6 +280,32 @@ def test_torch_dialect():
     assert(res[0]['uri'].endswith("init.cpp"))
     assert(res[0]['range']['start']['line'] == 94)
 
+    # Variable._execution_engine.run_backward
+    res = run_find_definition(server,
+                              join_path(pytorch_path, "torch/autograd/__init__.py"),
+                              24, 40)
+
+    assert(len(res) > 0)
+    assert(res[0]['uri'].endswith("python_engine.cpp"))
+    assert(res[0]['range']['start']['line'] == 13)
+
+    # _C._FunctionBase._do_forward
+    res = run_find_definition(server,
+                              join_path(pytorch_path, "torch/autograd/function.py"),
+                              5, 40)
+
+    assert(len(res) > 0)
+    assert(res[0]['uri'].endswith("python_function.cpp"))
+    assert(res[0]['range']['start']['line'] == 11)
+
+    # torch._C._get_qengine()
+    res = run_find_definition(server,
+                              join_path(pytorch_path, "torch/backends/quantized/__init__.py"),
+                              6, 45)
+
+    assert(len(res) > 0)
+    assert(res[0]['uri'].endswith("Module.cpp"))
+    assert(res[0]['range']['start']['line'] == 46)
 
 def test_mxnet_dialect():
     mx_path = os.path.join(curr_path, "..", "dummy_repo", "mxnet")

--- a/tests/python/test_langserver.py
+++ b/tests/python/test_langserver.py
@@ -221,6 +221,7 @@ def test_torch_dialect():
     uri = langserver.path2uri(pytorch_path)
     server.m_initialize(rootUri=uri)
 
+    # ops.quantized.conv2d
     res = run_find_definition(server,
                               join_path(pytorch_path, "torch/nn/quantized/modules/conv.py"),
                               38, 28)
@@ -228,13 +229,15 @@ def test_torch_dialect():
     assert(res[0]['uri'].endswith("qconv.cpp"))
     assert(res[0]['range']['start']['line'] == 2)
 
+    # torch._C._jit_script_class_compile
     res = run_find_definition(server,
                               join_path(pytorch_path, "torch/jit/__init__.py"),
                               20, 50)
     assert(len(res) > 0)
     assert(res[0]['uri'].endswith("init.cpp"))
-    assert(res[0]['range']['start']['line'] == 95)
+    assert(res[0]['range']['start']['line'] == 126)
 
+    # torch._C.CompilationUnit()
     res = run_find_definition(server,
                               join_path(pytorch_path, "torch/jit/__init__.py"),
                               25, 30)
@@ -243,6 +246,7 @@ def test_torch_dialect():
     assert(res[0]['range']['start']['line'] == 1)
     assert(res[0]['range']['end']['character'] == 27)
 
+    # torch.conv2d
     res = run_find_definition(server,
                               join_path(pytorch_path, "torch/nn/functional.py"),
                               16, 30)
@@ -253,10 +257,28 @@ def test_torch_dialect():
     # module._c._create_method_from_trace
     res = run_find_definition(server,
                               join_path(pytorch_path, "torch/jit/__init__.py"),
-                              74, 30)
+                              61, 30)
     assert(len(res) > 0)
     assert(res[0]['uri'].endswith("init.cpp"))
-    assert(res[0]['range']['start']['line'] == 125)
+    assert(res[0]['range']['start']['line'] == 105)
+
+    # self._c._get_method(attr)
+    res = run_find_definition(server,
+                              join_path(pytorch_path, "torch/jit/__init__.py"),
+                              106, 30)
+
+    assert(len(res) > 0)
+    assert(res[0]['uri'].endswith("init.cpp"))
+    assert(res[0]['range']['start']['line'] == 21)
+
+    # self._c._define(self._concrete_type, src, rcb)
+    res = run_find_definition(server,
+                              join_path(pytorch_path, "torch/jit/__init__.py"),
+                              98, 18)
+
+    assert(len(res) > 0)
+    assert(res[0]['uri'].endswith("init.cpp"))
+    assert(res[0]['range']['start']['line'] == 94)
 
 
 def test_mxnet_dialect():
@@ -288,7 +310,7 @@ def test_dgl_dialect():
 if __name__ == "__main__":
     # eyeballing test script
     logging.basicConfig(level=logging.INFO, format="[%(asctime)-15s] %(message)s")
-    test_tvm_dialect()
+    # test_tvm_dialect()
     test_torch_dialect()
-    test_mxnet_dialect()
-    test_dgl_dialect()
+    # test_mxnet_dialect()
+    # test_dgl_dialect()


### PR DESCRIPTION
* Add one more pattern to detect something like `module._c._create_method_from_trace`

* Minimally extends existing patterns to cover more general cases. For example, it can now jump from `_C._TensorBase.detach`, i.e symbols not beginning with `torch._C`. In addition, the pattern I used for generated functions like `"conv2d"` can be used for detecting other CPython-wrapped (not pybind) `PyMethodDef` functions. Now this pattern is used for more files so that it is now possible to jump from 
-- `Variable._execution_engine.run_backward`
-- `_C._FunctionBase._do_forward`
-- `torch._C._get_qengine()`
etc.

See the change in dialect/torch.py (at the top) and test_langserver.py (at the bottom) for detail.