### PR TITLE
Check pypath api is not None before accessing

### DIFF
--- a/python/ffi_navigator/dialect/tvm.py
+++ b/python/ffi_navigator/dialect/tvm.py
@@ -94,7 +94,7 @@ class TVMProvider(BaseProvider):
         results += self.py_reg_object(path, source, begin, end)
         results += self.py_reg_func(path, source, begin, end)
 
-        if path.startswith(self._pypath_api_internal):
+        if self._pypath_api_internal and path.startswith(self._pypath_api_internal):
             export_item = pattern.Export(
                 key_prefix="_", path=path,
                 fvar2key=lambda x: x,


### PR DESCRIPTION
`path.startswith(self._pypath_api_internal)` throws the below error when
`self._pypath_api_internal` is None

`TypeError: startswith first arg must be str or a tuple of str, not NoneType`